### PR TITLE
Minor fixes to the documentation + Ghost deploys

### DIFF
--- a/Kubernetes_v4/Scenarios/Scenario04/Ghost/2_deploy.yaml
+++ b/Kubernetes_v4/Scenarios/Scenario04/Ghost/2_deploy.yaml
@@ -21,7 +21,7 @@ spec:
         - containerPort: 2368
         env:
         - name: url
-          value: http://my-blog.com
+          value: http://192.168.0.63:30080
         volumeMounts:
         - mountPath: /var/lib/ghost/content
           name: content

--- a/Kubernetes_v4/Scenarios/Scenario04/README.md
+++ b/Kubernetes_v4/Scenarios/Scenario04/README.md
@@ -90,8 +90,8 @@ If you have configured Grafana, you can go back to your dashboard, to check what
 ## D. Cleanup (optional)
 
 :boom:  
-**The PVC will be reused in the [scenario8](../Scenario08) ('import a volume'). Only clean up if you dont plan to do the scenario8.**  
-Instead of deleting each object one by one, you can directly delete the namespace which will then remove all of its objects.  
+**The PVC will be reused in the [scenario7](../Scenario07) ('import a volume'). Only clean up if you dont plan to do the scenario7.**
+Instead of deleting each object one by one, you can directly delete the namespace which will then remove all of its objects.
 :boom:  
 
 ```bash

--- a/Kubernetes_v4/Scenarios/Scenario06/Ghost/2_deploy.yaml
+++ b/Kubernetes_v4/Scenarios/Scenario06/Ghost/2_deploy.yaml
@@ -21,7 +21,7 @@ spec:
         - containerPort: 2368
         env:
         - name: url
-          value: http://my-blog.com
+          value: http:192.168.0.61:30180
         volumeMounts:
         - mountPath: /var/lib/ghost/content
           name: content

--- a/Kubernetes_v4/Scenarios/Scenario07/1_NAS_Import/Ghost/1_pvc.yaml
+++ b/Kubernetes_v4/Scenarios/Scenario07/1_NAS_Import/Ghost/1_pvc.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: blog-content-import
-  namespace: ghostnas
+  namespace: ghost
 spec:
   accessModes:
   - ReadWriteMany

--- a/Kubernetes_v4/Scenarios/Scenario07/1_NAS_Import/Ghost/2_deploy.yaml
+++ b/Kubernetes_v4/Scenarios/Scenario07/1_NAS_Import/Ghost/2_deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: blogimport
@@ -21,7 +21,7 @@ spec:
         - containerPort: 2368
         env:
         - name: url
-          value: http://my-blog.com
+          value: http://192.168.0.63:30082
         volumeMounts:
         - mountPath: /var/lib/ghost/content
           name: content

--- a/Kubernetes_v4/Scenarios/Scenario07/1_NAS_Import/README.md
+++ b/Kubernetes_v4/Scenarios/Scenario07/1_NAS_Import/README.md
@@ -20,7 +20,7 @@ The full name of the volume is available in the PV metadata.
 You can retrieve it if with the 'kubectl describe' command, or use the following (note how to use the jsonpath feature!)
 
 ```bash
-$ kubectl get pv $( kubectl get pvc blog-content -n ghostnas -o=jsonpath='{.spec.volumeName}') -o=jsonpath='{.spec.csi.volumeAttributes.internalName}{"\n"}'
+$ kubectl get pv $( kubectl get pvc blog-content -n ghost -o=jsonpath='{.spec.volumeName}') -o=jsonpath='{.spec.csi.volumeAttributes.internalName}{"\n"}'
 nas1_pvc_e24c99b7_b4e7_4de1_b952_a8d451e7e735
 ```
 
@@ -28,8 +28,8 @@ Now that you know the full name of the volume, you can copy it. This copy will b
 Open Putty, connect to "cluster1" and finally enter all the following:
 
 ```bash
-vol clone create -flexclone to_import -vserver svm1 -parent-volume nas1_pvc_e24c99b7_b4e7_4de1_b952_a8d451e7e735
-vol clone split start -flexclone to_import
+vol clone create -flexclone to_import -vserver nfs_svm -parent-volume nas1_pvc_e24c99b7_b4e7_4de1_b952_a8d451e7e735
+vol clone split start -flexclone to_import -vserver nfs_svm
 ```
 
 In this example, the new volume's name is 'to_import'
@@ -47,7 +47,7 @@ $ tridentctl -n trident import volume NAS_Vol-default to_import -f Ghost/1_pvc.y
 | pvc-ac9ba4b2-7dce-4241-8c8e-a4ced9cf7dcf | 5.0 GiB | storage-class-nas | file     | dea226cf-7df7-4795-b1a1-3a4a3318a059 | online | true    |
 +------------------------------------------+---------+-------------------+----------+--------------------------------------+--------+---------+
 
-$ kubectl get pvc -n ghostnas
+$ kubectl get pvc -n ghost
 NAME                  STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS        AGE
 blog-content          Bound    pvc-e24c99b7-b4e7-4de1-b952-a8d451e7e735   5Gi        RWX            storage-class-nas   19h
 blog-content-import   Bound    pvc-ac9ba4b2-7dce-4241-8c8e-a4ced9cf7dcf   5Gi        RWX            storage-class-nas   21m
@@ -56,14 +56,14 @@ blog-content-import   Bound    pvc-ac9ba4b2-7dce-4241-8c8e-a4ced9cf7dcf   5Gi   
 Notice that the volume full name on the storage backend has changed to respect the CSI specifications:
 
 ```bash
-$ kubectl get pv $( kubectl get pvc blog-content-import -n ghostnas -o=jsonpath='{.spec.volumeName}') -o=jsonpath='{.spec.csi.volumeAttributes.internalName}{"\n"}'
+$ kubectl get pv $( kubectl get pvc blog-content-import -n ghost -o=jsonpath='{.spec.volumeName}') -o=jsonpath='{.spec.csi.volumeAttributes.internalName}{"\n"}'
 nas1_pvc_ac9ba4b2_7dce_4241_8c8e_a4ced9cf7dcf
 ```
 
 Even though the name of the original PV has changed, you can still see it if you look into its annotations.
 
 ```bash
-$ kubectl describe pvc blog-content-import -n ghostnas | grep importOriginalName
+$ kubectl describe pvc blog-content-import -n ghost | grep importOriginalName
                trident.netapp.io/importOriginalName: to_import
 ```
 
@@ -72,12 +72,12 @@ $ kubectl describe pvc blog-content-import -n ghostnas | grep importOriginalName
 You can now create the deployment & expose it on a new port
 
 ```bash
-$ kubectl create -n ghostnas -f Ghost/2_deploy.yaml
+$ kubectl create -n ghost -f Ghost/2_deploy.yaml
 deployment.apps/blogimport created
-$ kubectl create -n ghostnas -f Ghost/3_service.yaml
+$ kubectl create -n ghost -f Ghost/3_service.yaml
 service/blogimport created
 
-$ kubectl all -n ghostnas
+$ kubectl all -n ghost
 NAME                           READY   STATUS    RESTARTS   AGE
 pod/blog-cd5894ddd-d2tqp       1/1     Running   0          20h
 pod/blogimport-66945d9-bsw9b   1/1     Running   0          24m
@@ -108,8 +108,8 @@ If you have configured Grafana, you can go back to your dashboard, to check what
 Instead of deleting each object one by one, you can directly delete the namespace which will then remove all of its objects.
 
 ```bash
-$ kubectl delete ns ghostnas
-namespace "ghostnas" deleted
+$ kubectl delete ns ghost
+namespace "ghost" deleted
 ```
 
 ## F. What's next

--- a/Kubernetes_v4/Scenarios/Scenario13/Ghost_clone/2_deploy.yaml
+++ b/Kubernetes_v4/Scenarios/Scenario13/Ghost_clone/2_deploy.yaml
@@ -21,7 +21,7 @@ spec:
         - containerPort: 2368
         env:
         - name: url
-          value: http://my-blog-clone.com
+          value: http://192.168.0.63:30081/
         volumeMounts:
         - mountPath: /data
           name: content

--- a/Kubernetes_v4/Scenarios/Scenario13/ghost.yaml
+++ b/Kubernetes_v4/Scenarios/Scenario13/ghost.yaml
@@ -35,7 +35,7 @@ spec:
         - containerPort: 2368
         env:
         - name: url
-          value: http://my-blog.com
+          value: http://192.168.0.63:30080
         volumeMounts:
         - mountPath: /data
           name: content


### PR DESCRIPTION
Creating this PR to address:

1. Minor documentation fixes [redirection links in some of the READMEs, as well as updates to SVM names in the latest LoD image]
2. the `url` env variable in the sample app deploys. This should ideally be set by the service (if the service is LoadBalancer), but here it should point to the nodeIP:nodePort