### PR TITLE
Add volume expansion

### DIFF
--- a/Kubernetes_v4/Scenarios/Scenario02/sc-csi-ontap-nas cert.yaml
+++ b/Kubernetes_v4/Scenarios/Scenario02/sc-csi-ontap-nas cert.yaml
@@ -6,3 +6,4 @@ provisioner: csi.trident.netapp.io
 parameters:
   backendType: "ontap-nas"
   storagePools: "nas-cert:aggr1"
+allowVolumeExpansion: true


### PR DESCRIPTION
General best practise: Storage Classes should always include the allowVolumeExpansion parameter, as this cannot be added to a PV later on.